### PR TITLE
Fix date picker to open with the selected month instead of defaulting to the current month

### DIFF
--- a/src/components/custom/v2/add-entry/date-picker.tsx
+++ b/src/components/custom/v2/add-entry/date-picker.tsx
@@ -21,6 +21,7 @@ export function DatePicker({
 				<Calendar
 					mode="single"
 					selected={value}
+					defaultMonth={value}
 					onSelect={onValueChange}
 					initialFocus
 					weekStartsOn={1}


### PR DESCRIPTION
This pull request fixes an issue where the date picker would always open with the current month, even after a different date from another month was selected. Now, the date picker will remember the selected date and open with the corresponding month.

Before:
![before](https://github.com/user-attachments/assets/9a686b93-169f-4535-a90a-26742ff6f320)

After:
![after](https://github.com/user-attachments/assets/1e10f4aa-efff-4615-90a5-ee80f9f06d75)
