### PR TITLE
fix: show entries older than 24 months

### DIFF
--- a/src/evolu-queries.ts
+++ b/src/evolu-queries.ts
@@ -269,9 +269,9 @@ export const generateOccurrences = (
 ) => {
 	const occurences = [];
 	const MAX_OCCURENCES = {
-		year: 1,
-		month: 24,
-		week: 52,
+		year: 20,
+		month: 240,
+		week: 1248,
 	} as const;
 
 	const frequency = recurringConfig.frequency;


### PR DESCRIPTION
This pull request fixes an issue where entries with installments longer than 24 months were not appearing in the list.

Before:
![error](https://github.com/user-attachments/assets/1d752ae7-333a-4c91-ad57-aab408e08c2d)

After:
![image](https://github.com/user-attachments/assets/5bc6330c-71d8-4130-a84a-1280243754d8)
